### PR TITLE
AB2-16: use artifact from repository.cliqz.com

### DIFF
--- a/mozilla-release/Makefile.in
+++ b/mozilla-release/Makefile.in
@@ -210,7 +210,9 @@ binaries::
 endif
 
 recurse_artifact:
-	$(topsrcdir)/mach --log-no-times artifact install
+#	$(topsrcdir)/mach --log-no-times artifact install
+	$(topsrcdir)/mach --log-no-times artifact install https://repository.cliqz.com/dist/android/artifacts/$(GRE_MILESTONE)/target.apk
+	$(topsrcdir)/mach --log-no-times artifact install https://repository.cliqz.com/dist/android/artifacts/$(GRE_MILESTONE)/target.common.tests.zip
 
 ifdef MOZ_WIDGET_TOOLKIT
 ifdef ENABLE_TESTS

--- a/mozilla-release/python/mozbuild/mozbuild/mach_commands.py
+++ b/mozilla-release/python/mozbuild/mozbuild/mach_commands.py
@@ -1149,9 +1149,12 @@ class PackageFrontend(MachCommandBase):
         if conditions.is_hg(build_obj):
             hg = build_obj.substs['HG']
 
-        git = None
-        if conditions.is_git(build_obj):
-            git = build_obj.substs['GIT']
+        git = '/usr/local/bin/git'
+        if 'GIT' in os.environ:
+            git = os.environ['GIT']
+#        git = None
+#        if conditions.is_git(build_obj):
+#            git = build_obj.substs['GIT']
 
         from mozbuild.artifacts import Artifacts
         artifacts = Artifacts(tree, self.substs, self.defines, job,


### PR DESCRIPTION
This artifact must be putted to our S3 bucket when checkout a new original FF version. This artifact could be taken from Firefox build infrastructure. To find proper artifact - get a commit ID from Mercurial, related to FF tag. Next by this commit find a proper build job in https://treeherder.mozilla.org/#/jobs?repo=mozilla-release, build for "Android 4.0 API16+ opt" and on bottom of build task you can find "Task" id. Click on it to get a build result in Taskcluster. On "Run Artifacts" find needed files and place them in proper location in our S3 bucket. Folder must have name same as version in mozilla-release/config/milestone.txt file.