### PR TITLE
disable extension valid signed check

### DIFF
--- a/mozilla-release/toolkit/mozapps/extensions/internal/XPIInstall.jsm
+++ b/mozilla-release/toolkit/mozapps/extensions/internal/XPIInstall.jsm
@@ -186,10 +186,7 @@ const TEMP_INSTALL_ID_GEN_SESSION =
 
 // Whether add-on signing is required.
 function mustSign(aType) {
-  if (!SIGNED_TYPES.has(aType))
-    return false;
-
-  return AddonSettings.REQUIRE_SIGNING;
+  return false;
 }
 
 const MSG_JAR_FLUSH = "AddonJarFlush";

--- a/mozilla-release/toolkit/mozapps/extensions/internal/XPIProvider.jsm
+++ b/mozilla-release/toolkit/mozapps/extensions/internal/XPIProvider.jsm
@@ -243,10 +243,7 @@ const ALL_EXTERNAL_TYPES = new Set([
 
 // Whether add-on signing is required.
 function mustSign(aType) {
-  if (!SIGNED_TYPES.has(aType))
-    return false;
-
-  return AddonSettings.REQUIRE_SIGNING;
+  return false;
 }
 
 // Keep track of where we are in startup for telemetry


### PR DESCRIPTION
@spacifici This PR disables checks for valid signature of the extension and includes the latest CLIQZ Search extension so that the other developers don't have to build it themself. We can keep it as starter.