### PR TITLE
Changed the Docker Container name to the Firefox Base Version - upstream-releases

### DIFF
--- a/Jenkinsfile.docker
+++ b/Jenkinsfile.docker
@@ -1,16 +1,16 @@
 #!/bin/env groovy
 
 node('us-east-1 && ubuntu && docker && !gpu') {
-    
-    def hash = ""
-    
+
+    def dockerTag
+
     stage('Checkout') {
         checkout scm
-        sh "git fetch origin"
-        hash = sh(returnStdout: true, script: """git log refs/remotes/origin/upstream-releases --format="%H" -n 1""").trim()
+        dockerTag = readFile('mozilla-release/browser/config/version_display.txt')
     }
-    def dockerTag = "${hash}"
+
     def baseImageName = "browser-f/android:${dockerTag}"
+    
     stage('Build Create Docker Image') {
         docker.withRegistry('https://141047255820.dkr.ecr.us-east-1.amazonaws.com'){
             def baseImage  = docker.build(baseImageName, '--build-arg UID=`id -u` --build-arg GID=`id -g` .')


### PR DESCRIPTION
Note: We will no longer use the Hash of the commit, instead we will use the version number of the Firefox Base Code.