### PR TITLE
AB2-81,83,101: add Subscriptions & Notifications category to general settings menu

### DIFF
--- a/mozilla-release/mobile/android/app/src/main/res/xml/preferences.xml
+++ b/mozilla-release/mobile/android/app/src/main/res/xml/preferences.xml
@@ -45,13 +45,6 @@
                android:value="preferences_accessibility" />
     </PreferenceScreen>
 
-    <PreferenceScreen android:title="@string/pref_category_notifications"
-        android:summary="@string/pref_category_notifications_summary"
-        android:fragment="org.mozilla.gecko.preferences.GeckoPreferenceFragment">
-        <extra android:name="resource"
-            android:value="preferences_notifications"/>
-    </PreferenceScreen>
-
     <PreferenceScreen android:title="@string/pref_category_advanced"
                       android:summary="@string/pref_category_advanced_summary"
                       android:fragment="org.mozilla.gecko.preferences.GeckoPreferenceFragment"
@@ -75,6 +68,17 @@
                                                   android:persistent="false"
                                                   url="https://support.mozilla.org/kb/make-firefox-default-browser-android?utm_source=inproduct&amp;utm_medium=settings&amp;utm_campaign=mobileandroid"/>
 
+    <!-- Cliqz start -->
+    <!-- add a key to notification preference to enable hiding it -->
+    <PreferenceScreen android:title="@string/pref_category_notifications"
+        android:summary="@string/pref_category_notifications_summary"
+        android:fragment="org.mozilla.gecko.preferences.GeckoPreferenceFragment"
+        android:key="android.not_a_preference.notifications.screen">
+        <extra android:name="resource"
+            android:value="preferences_notifications"/>
+    </PreferenceScreen>
+
+    <!-- add a key to vendor preference to enable hiding it -->
     <PreferenceScreen android:title="@string/pref_category_vendor"
                       android:summary="@string/pref_category_vendor_summary"
                       android:fragment="org.mozilla.gecko.preferences.GeckoPreferenceFragment"
@@ -83,7 +87,6 @@
                android:value="preferences_vendor"/>
     </PreferenceScreen>
 
-    <!-- Cliqz start -->
     <!-- add human web setting -->
     <PreferenceScreen android:title="@string/pref_category_human_web"
         android:summary="@string/pref_category_human_web_summary"

--- a/mozilla-release/mobile/android/app/src/main/res/xml/preferences_general.xml
+++ b/mozilla-release/mobile/android/app/src/main/res/xml/preferences_general.xml
@@ -105,6 +105,21 @@
             android:key="android.not_a_preference.about.myoffrz"
             android:title="@string/pref_about_myoffrz" />
     </PreferenceCategory>
+
+    <!-- add Subscriptions & Notifications category -->
+    <PreferenceCategory android:title="@string/pref_subscriptions_notifications_category">
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="pref.news.notifications"
+            android:title="@string/pref_news_notifications" />
+        <CheckBoxPreference android:key="android.not_a_preference.notifications.whats_new"
+            android:title="@string/pref_whats_new_notification"
+            android:summary="@string/pref_whats_new_notification_summary"
+            android:defaultValue="true" />
+        <Preference
+            android:key="pref.rest.subscriptions"
+            android:title="@string/pref_reset_subscriptions" />
+    </PreferenceCategory>
     <!-- Cliqz end -->
 
 </PreferenceScreen>

--- a/mozilla-release/mobile/android/base/java/org/mozilla/gecko/preferences/GeckoPreferenceFragment.java
+++ b/mozilla-release/mobile/android/base/java/org/mozilla/gecko/preferences/GeckoPreferenceFragment.java
@@ -40,6 +40,7 @@ import static org.mozilla.gecko.preferences.GeckoPreferences.PREFS_COMPACT_TABS;
 import static org.mozilla.gecko.preferences.GeckoPreferences.PREFS_DYNAMIC_TOOLBAR;
 import static org.mozilla.gecko.preferences.GeckoPreferences.PREFS_GENERAL_HOME;
 import static org.mozilla.gecko.preferences.GeckoPreferences.PREFS_GENERAL_LANGUAGE;
+import static org.mozilla.gecko.preferences.GeckoPreferences.PREFS_NOTIFICATIONS_SCREEN;
 import static org.mozilla.gecko.preferences.GeckoPreferences.PREFS_VENDOR_SCREEN;
 
 /* A simple implementation of PreferenceFragment for large screen devices
@@ -105,9 +106,10 @@ public class GeckoPreferenceFragment extends PreferenceFragment {
             // remove Compact tabs setting from General settings
             removePreference(screen,PREFS_COMPACT_TABS);
         }
-        // remove Mozilla Fennec (About, Feedback, FAQ)
+        // remove Mozilla Fennec (About, Feedback, FAQ) & notifications screens
         else if(res == R.xml.preferences){
             removePreference(screen, PREFS_VENDOR_SCREEN);
+            removePreference(screen, PREFS_NOTIFICATIONS_SCREEN);
         }
         /* Cliqz end */
         mPrefsRequest = ((GeckoPreferences)getActivity()).setupPreferences(screen);

--- a/mozilla-release/mobile/android/base/java/org/mozilla/gecko/preferences/GeckoPreferences.java
+++ b/mozilla-release/mobile/android/base/java/org/mozilla/gecko/preferences/GeckoPreferences.java
@@ -215,9 +215,10 @@ public class GeckoPreferences
     final private int DIALOG_CREATE_BLOCK_ADS_WHAT_FAIR = 2;
     // add rate cliqz browser to the settings menu
     private static final String PREFS_rate_cliqz = NON_PREF_PREFIX + "rate.cliqz";
-    // add keys for General Home , Vendor screen , General language
+    // add keys for General Home , Vendor screen , notifications screen, General language
     public static final String PREFS_GENERAL_HOME = NON_PREF_PREFIX + "general.home";
     public static final String PREFS_VENDOR_SCREEN = NON_PREF_PREFIX + "vendor.screen";
+    public static final String PREFS_NOTIFICATIONS_SCREEN = NON_PREF_PREFIX + "notifications.screen";
     public static final String PREFS_GENERAL_LANGUAGE = NON_PREF_PREFIX + "general.language";
     // add support cliqz to the settings menu
     private static final String PREFS_SUPPORT_CLIQZ = NON_PREF_PREFIX + "support.cliqz";

--- a/mozilla-release/mobile/android/base/java/org/mozilla/gecko/preferences/GeckoPreferences.java
+++ b/mozilla-release/mobile/android/base/java/org/mozilla/gecko/preferences/GeckoPreferences.java
@@ -50,6 +50,7 @@ import android.widget.LinearLayout;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import org.json.JSONArray;
 import org.mozilla.gecko.AboutPages;
@@ -88,6 +89,7 @@ import org.mozilla.gecko.util.EventCallback;
 import org.mozilla.gecko.util.GeckoBundle;
 import org.mozilla.gecko.util.HardwareUtils;
 import org.mozilla.gecko.util.InputOptionsUtils;
+import org.mozilla.gecko.util.SubscriptionsManager;
 import org.mozilla.gecko.util.ThreadUtils;
 import org.mozilla.gecko.util.ViewUtil;
 
@@ -233,6 +235,9 @@ public class GeckoPreferences
     // add show myoffrz and about my offrz to general settings menu
     public static final String PREFS_SHOW_MYOFFRZ = "pref.show.myoffrz";
     public static final String PREFS_ABOUT_MYOFFRZ = NON_PREF_PREFIX+ "about.myoffrz";
+    // add Subscriptions key and dialog for reset it
+    public static final String PREFS_RESET_SUBSCRIPTIONS = "pref.rest.subscriptions";
+    final private int DIALOG_CREATE_RESET_SUBSCRIPTIONS = 3;
     /* Cliqz end */
 
     private final Map<String, PrefHandler> HANDLERS;
@@ -907,9 +912,20 @@ public class GeckoPreferences
                     final String url = getResources().getString(R.string.pref_myoffrz_url);
                     ((LinkPreference) pref).setUrl(url);
                 }
+                // Set default value of show my offrz depend on system language
                 else if (PREFS_SHOW_MYOFFRZ.equals(key)){
                     ((CheckBoxPreference)pref).setDefaultValue(isMyOffrzSupportedForLang());
                     ((CheckBoxPreference)pref).setChecked(isMyOffrzEnable(getApplicationContext()));
+                }
+                // Open dialog
+                else if(PREFS_RESET_SUBSCRIPTIONS.equals(key)){
+                    pref.setOnPreferenceClickListener(new OnPreferenceClickListener() {
+                        @Override
+                        public boolean onPreferenceClick(Preference preference) {
+                            showDialog(DIALOG_CREATE_RESET_SUBSCRIPTIONS);
+                            return true;
+                        }
+                    });
                 }
                 /* Cliqz end */
 
@@ -1435,6 +1451,28 @@ public class GeckoPreferences
                 ((TextView)dialog.findViewById(android.R.id.message)).setMovementMethod
                         (CustomLinkMovementMethod.getInstance(this));
                 break;
+            case DIALOG_CREATE_RESET_SUBSCRIPTIONS:
+                builder.setTitle(R.string.pref_reset_subscriptions)
+                        .setMessage(R.string.pref_reset_subscriptions_description)
+                        .setCancelable(true)
+                        .setNegativeButton(R.string.button_no, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                dialog.dismiss();
+                            }
+                        })
+                        .setPositiveButton(R.string.button_yes, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                final Context context = getApplicationContext();
+                                final SubscriptionsManager subscriptionsManager = new
+                                        SubscriptionsManager(context);
+                                subscriptionsManager.resetSubscriptions();
+                                Toast.makeText(context, R.string.pref_reset_subscriptions_toast,
+                                        Toast.LENGTH_SHORT).show();
+                            }
+                        })
+                        .show();
             /* Cliqz end */
             default:
                 return null;

--- a/mozilla-release/mobile/android/base/java/org/mozilla/gecko/util/SubscriptionsManager.java
+++ b/mozilla-release/mobile/android/base/java/org/mozilla/gecko/util/SubscriptionsManager.java
@@ -1,0 +1,209 @@
+package org.mozilla.gecko.util;
+
+import android.content.Context;
+import android.support.annotation.UiThread;
+import android.support.annotation.VisibleForTesting;
+import android.util.Log;
+import com.google.android.exoplayer2.util.Util;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Manage subscriptions (duh!). This will store the subscriptions list every time the user adds
+ * one of them.<br>
+ * Subscriptions are stored in a text file, one per line:
+ * <pre>
+ *     &lt;type&gt;|&lt;sub-type&gt;|&lt;value&gt;
+ * </pre>
+ * In example:
+ * <pre>
+ *     soccer|game|123
+ *     soccer|team|6789
+ *     basketball|league|456
+ * </pre>
+ *
+ * Copyright © Cliqz 2018
+ */
+
+public class SubscriptionsManager {
+
+    private final static String TAG = SubscriptionsManager.class.getSimpleName();
+
+    private final static String SUBSCRIPTIONS_FILE_NAME = "subscriptions.txt";
+
+    private final CountDownLatch latch;
+    private final ExecutorService executor;
+
+    @SuppressWarnings("WeakerAccess")
+    @VisibleForTesting
+    final File subscriptionsFile;
+    private final Map<String, Map<String, Set<String>>> subscriptions = new HashMap<>();
+
+    public SubscriptionsManager(Context context) {
+        latch = new CountDownLatch(1);
+        subscriptionsFile = getSubscriptionsFile(context);
+        executor = Executors.newSingleThreadExecutor();
+        loadSubscriptions();
+    }
+
+    @VisibleForTesting
+    static File getSubscriptionsFile(Context context) {
+        return new File(context.getFilesDir(), SUBSCRIPTIONS_FILE_NAME);
+    }
+
+    /**
+     * Add the subscription identified by type, sub-type and id. This cause a persist operation.
+     * @param type the main type (i.e. soccer, tennis, weather)
+     * @param subType the sub-type (i.e. team, game, city or country)
+     * @param id a unique identifier for the type/sub-type, can be numbers or name (i.e. 123 or
+     *           "FC Bayern München")
+     */
+    @UiThread
+    public void addSubscription(String type, String subType, String id) {
+        try {
+            latch.await();
+            final Map<String, Set<String>> typeMap = getType(type);
+            final Set<String> values = getSet(typeMap, subType);
+            values.add(id);
+            saveSubscriptions();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Remove the subscription identified by type, sub-type and id. This cause a persist operation.
+     * @see SubscriptionsManager#addSubscription(String, String, String)
+     * @param type the main type
+     * @param subType the sub-type
+     * @param id a unique identifier for the type/sub-type
+     */
+    @UiThread
+    public void removeSubscription(String type, String subType, String id) {
+        try {
+            latch.await();
+            final Map<String, Set<String>> typeMap = getType(type);
+            final Set<String> values = getSet(typeMap, subType);
+            values.remove(id);
+            saveSubscriptions();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void loadSubscriptions() {
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                BufferedReader reader = null;
+                try {
+                    reader = new BufferedReader(new FileReader(subscriptionsFile));
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        final String[] parts = line.split("\\|");
+                        final String type = parts[0];
+                        final String subtype = parts[1];
+                        final String value = parts[2];
+                        final Map<String, Set<String>> typeMap = getType(type);
+                        final Set<String> valuesSet = getSet(typeMap, subtype);
+                        valuesSet.add(value);
+                    }
+                } catch (Exception e) {
+                    Log.i(TAG, "Can't load " + subscriptionsFile.getName());
+                } finally {
+                    Util.closeQuietly(reader);
+                    latch.countDown();
+                }
+            }
+        });
+    }
+
+    private void saveSubscriptions() {
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                final File tmpFile = new File(subscriptionsFile.getPath() + "_" +
+                        System.currentTimeMillis());
+                //noinspection ResultOfMethodCallIgnored
+                tmpFile.delete();
+                BufferedWriter writer = null;
+                try {
+                    writer = new BufferedWriter(new FileWriter(tmpFile, false));
+                    for (final String type: subscriptions.keySet()) {
+                        final Map<String, Set<String>> entry = subscriptions.get(type);
+                        for (final String key: entry.keySet()) {
+                            final Set<String> values = entry.get(key);
+                            for (final String value: values) {
+                                writer
+                                    .append(type).append("|")
+                                    .append(key).append("|")
+                                    .append(value);
+                                writer.newLine();
+                            }
+                        }
+                    }
+                    // Close the writer before renaming the file
+                    Util.closeQuietly(writer);
+                    synchronized (SubscriptionsManager.this) {
+                        //noinspection ResultOfMethodCallIgnored
+                        tmpFile.renameTo(subscriptionsFile);
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    Util.closeQuietly(writer);
+                }
+            }
+        });
+    }
+
+    private Set<String> getSet(Map<String, Set<String>> typeMap, String subtype) {
+        Set<String> values = typeMap.get(subtype);
+        if (values == null) {
+            values = new HashSet<>();
+            typeMap.put(subtype, values);
+        }
+        return values;
+    }
+
+    private Map<String, Set<String>> getType(String type) {
+        Map<String, Set<String>> entry = subscriptions.get(type);
+        if (entry == null) {
+            entry = new HashMap<>();
+            subscriptions.put(type, entry);
+        }
+        return entry;
+    }
+
+    public boolean isSubscribed(String type, String subtype, String value) {
+        final Map<String, Set<String>> subtypes = getType(type);
+        final Set<String> values = getSet(subtypes, subtype);
+        return values.contains(value);
+    }
+
+    /**
+     * Reset all the inner data, after this the user has no subscription at all. This cause a
+     * persist operation.
+     */
+    @UiThread
+    public void resetSubscriptions() {
+        try {
+            latch.await();
+            // We do not want to clear the data before loading stuff from the disk
+            subscriptions.clear();
+            saveSubscriptions();
+        } catch (InterruptedException e) {
+            Log.e(TAG, "Interrupted");
+        }
+    }
+}

--- a/mozilla-release/mobile/android/base/locales/en-US/android_strings.dtd
+++ b/mozilla-release/mobile/android/base/locales/en-US/android_strings.dtd
@@ -956,4 +956,8 @@ See also https://bug1409261.bmoattachments.org/attachment.cgi?id=8919897 -->
 <!ENTITY pref_show_myoffrz "Show MyOffrz">
 <!ENTITY pref_about_myoffrz "About MyOffrz">
 
+<!-- General Settings - Subscriptions and Notifications -->
+<!ENTITY pref_subscriptions_notifications_category "Subscriptions and Notifications">
+<!ENTITY pref_news_notifications "News notifications">
+<!ENTITY pref_reset_subscriptions "Reset all subscriptions">
 <!-- Cliqz end -->

--- a/mozilla-release/mobile/android/base/locales/en-US/android_strings.dtd
+++ b/mozilla-release/mobile/android/base/locales/en-US/android_strings.dtd
@@ -960,4 +960,6 @@ See also https://bug1409261.bmoattachments.org/attachment.cgi?id=8919897 -->
 <!ENTITY pref_subscriptions_notifications_category "Subscriptions and Notifications">
 <!ENTITY pref_news_notifications "News notifications">
 <!ENTITY pref_reset_subscriptions "Reset all subscriptions">
+<!ENTITY pref_reset_subscriptions_description "Would you like to reset all your subscriptions (e.g. to Bundesliga games)?">
+<!ENTITY pref_reset_subscriptions_toast "All subscriptions reset">
 <!-- Cliqz end -->

--- a/mozilla-release/mobile/android/base/strings.xml.in
+++ b/mozilla-release/mobile/android/base/strings.xml.in
@@ -734,5 +734,7 @@
   <string name="pref_subscriptions_notifications_category">&pref_subscriptions_notifications_category;</string>
   <string name="pref_news_notifications">&pref_news_notifications;</string>
   <string name="pref_reset_subscriptions">&pref_reset_subscriptions;</string>
+  <string name="pref_reset_subscriptions_description">&pref_reset_subscriptions_description;</string>
+  <string name="pref_reset_subscriptions_toast">&pref_reset_subscriptions_toast;</string>
   <!-- Cliqz end -->
 </resources>

--- a/mozilla-release/mobile/android/base/strings.xml.in
+++ b/mozilla-release/mobile/android/base/strings.xml.in
@@ -724,10 +724,15 @@
   <string name="pref_cliqz_tab_topsites">&pref_cliqz_tab_topsites;</string>
   <string name="pref_cliqz_tab_news">&pref_cliqz_tab_news;</string>
 
-  <!-- General Settings - CliqzTab -->
+  <!-- General Settings - MyOffrz -->
   <string name="pref_myoffrz_category">&pref_myoffrz_category;</string>
   <string name="pref_show_myoffrz">&pref_show_myoffrz;</string>
   <string name="pref_about_myoffrz">&pref_about_myoffrz;</string>
   <string name="pref_myoffrz_url">&pref_myoffrz_url;</string>
+
+  <!-- General Settings - Subscriptions and Notifications -->
+  <string name="pref_subscriptions_notifications_category">&pref_subscriptions_notifications_category;</string>
+  <string name="pref_news_notifications">&pref_news_notifications;</string>
+  <string name="pref_reset_subscriptions">&pref_reset_subscriptions;</string>
   <!-- Cliqz end -->
 </resources>


### PR DESCRIPTION
About news notifications push notification , I didn't handle it in this PR
FF has GcmMessageListenerService.java and PushService.java
that listens for others messages, we need to filter it first.

another thing should we use FCM instead because as far I know "The GCM server and client APIs are deprecated and will be removed as soon as April 11, 2019."