### PR TITLE
AB-209 always show overview as the first page of cc

### DIFF
--- a/mozilla-release/mobile/android/base/java/org/mozilla/gecko/BrowserApp.java
+++ b/mozilla-release/mobile/android/base/java/org/mozilla/gecko/BrowserApp.java
@@ -4809,6 +4809,7 @@ public class BrowserApp extends GeckoApp
             mControlCenterContainer.setVisibility(View.GONE);
         } else {
             mControlCenterContainer.setVisibility(View.VISIBLE);
+            mControlCenterPager.setCurrentItem(0);
             EventDispatcher.getInstance().dispatch("Privacy:GetInfo",null);
             ControlCenterMetrics.show();
         }

--- a/mozilla-release/mobile/android/base/java/org/mozilla/gecko/activitystream/homepanel/topnews/TopNewsLoader.java
+++ b/mozilla-release/mobile/android/base/java/org/mozilla/gecko/activitystream/homepanel/topnews/TopNewsLoader.java
@@ -100,8 +100,6 @@ public class TopNewsLoader extends AsyncTaskLoader<List<TopNews>> {
         String lang = null;
         String country = GeckoSharedPrefs.forApp(getContext()).getString(SearchEngineManager
                 .PREF_REGION_KEY, null);
-
-        String newsEdition = "intl";
         if (parts.length > 0) {
             lang = parts[0].toLowerCase();
         }
@@ -109,11 +107,7 @@ public class TopNewsLoader extends AsyncTaskLoader<List<TopNews>> {
         sb.append("&locale=").append(locale);
         if (lang != null) {
             sb.append("&lang=").append(lang);
-            if (lang.equals(Locale.GERMAN.getLanguage()) || lang.equals(Locale.FRENCH.getLanguage())) {
-                newsEdition = lang;
-            }
         }
-        sb.append("&edition=").append(newsEdition);
         if (country != null) {
             sb.append("&country=").append(country);
         }


### PR DESCRIPTION
Also removes the redundant news edition  parameter. Confirmed this with Heeren.